### PR TITLE
fix: make filtered-content-layout block standalone with embedded header

### DIFF
--- a/public/r/blocks/filtered-content-layout.json
+++ b/public/r/blocks/filtered-content-layout.json
@@ -9,6 +9,11 @@
     "https://eco-design-system-2.vercel.app/r/styles/avatar.json",
     "https://eco-design-system-2.vercel.app/r/styles/input.json",
     "https://eco-design-system-2.vercel.app/r/styles/icons.json",
+    "https://eco-design-system-2.vercel.app/r/styles/breadcrumb.json",
+    "https://eco-design-system-2.vercel.app/r/styles/checkbox.json",
+    "https://eco-design-system-2.vercel.app/r/styles/label.json",
+    "https://eco-design-system-2.vercel.app/r/styles/select.json",
+    "https://eco-design-system-2.vercel.app/r/styles/slider.json",
     "https://eco-design-system-2.vercel.app/r/styles/sonner.json",
     "https://eco-design-system-2.vercel.app/r/components/panel.json",
     "https://eco-design-system-2.vercel.app/r/components/brand-header.json",
@@ -21,6 +26,12 @@
       "type": "registry:file",
       "target": "app/layout.tsx",
       "content": "import { Geist_Mono, Inter, Montserrat } from \"next/font/google\";\nimport React, { type ReactNode } from \"react\";\n\nimport { cn } from \"@/lib/utils\";\n\nimport \"@/app/globals.css\";\n\nconst InterSans = Inter({\n  subsets: [\"latin\"],\n  variable: \"--font-sans\",\n});\n\nconst GeistMono = Geist_Mono({\n  subsets: [\"latin\"],\n  variable: \"--font-mono\",\n});\n\nconst MontserratSerif = Montserrat({\n  subsets: [\"latin\"],\n  variable: \"--font-serif\",\n});\n\nexport default function ShellLayout({\n  children,\n}: Readonly<{\n  children: ReactNode;\n}>) {\n  return (\n    <html\n      lang=\"en\"\n      className={cn(\n        InterSans.variable,\n        GeistMono.variable,\n        MontserratSerif.variable,\n        \"bg-background text-foreground\",\n      )}\n    >\n      <body>\n        <main className=\"flex w-full\">\n          <div className=\"w-full\">{children}</div>\n        </main>\n      </body>\n    </html>\n  );\n}\n"
+    },
+    {
+      "path": "src/components/ui/header.tsx",
+      "type": "registry:component",
+      "target": "components/ui/header.tsx",
+      "content": "\"use client\";\n\nimport * as React from \"react\";\nimport { cn } from \"@/lib/utils\";\nimport {\n  Breadcrumb,\n  BreadcrumbItem,\n  BreadcrumbLink,\n  BreadcrumbList,\n  BreadcrumbPage,\n  BreadcrumbSeparator,\n} from \"@/components/ui/breadcrumb\";\n\n/**\n * Header component for creating flexible headers that can contain controls for panels.\n *\n * Features:\n * - Flexible layout with left and right content areas\n * - Built-in breadcrumb support\n * - Button and control placement on the right\n * - Consistent styling with design system\n * - Responsive design\n *\n * @example\n * ```tsx\n * <Header\n *   breadcrumbs={[\n *     { label: \"Home\", href: \"/\" },\n *     { label: \"Weather Dashboard\", href: \"/dashboard\" }\n *   ]}\n *   rightContent={<Button>Secondary</Button>}\n * />\n * ```\n */\n\ninterface BreadcrumbItem {\n  label: string;\n  href?: string;\n}\n\ninterface HeaderProps {\n  /** Breadcrumb navigation items */\n  breadcrumbs?: BreadcrumbItem[];\n  /** Content to display on the left side (overrides breadcrumbs) */\n  leftContent?: React.ReactNode;\n  /** Content to display on the right side (buttons, controls, etc.) */\n  rightContent?: React.ReactNode;\n  /** Additional CSS classes */\n  className?: string;\n}\n\n/**\n * Header component for creating flexible headers with breadcrumbs and controls.\n *\n * @param props - Header component props\n * @returns JSX element\n */\nexport function Header({\n  breadcrumbs,\n  leftContent,\n  rightContent,\n  className,\n  ...props\n}: HeaderProps) {\n  return (\n    <header\n      className={cn(\n        \"flex w-full h-12 items-center justify-between border-b border-border bg-background px-3 py-2 shadow-sm\",\n        className\n      )}\n      {...props}\n    >\n      {/* Left side content */}\n      <div className=\"flex items-center\">\n        {leftContent ? (\n          leftContent\n        ) : breadcrumbs ? (\n          <Breadcrumb>\n            <BreadcrumbList>\n              {breadcrumbs.map((item, index) => (\n                <React.Fragment key={index}>\n                  {index > 0 && <BreadcrumbSeparator />}\n                  <BreadcrumbItem>\n                    {item.href ? (\n                      <BreadcrumbLink href={item.href}>\n                        {item.label}\n                      </BreadcrumbLink>\n                    ) : (\n                      <BreadcrumbPage>{item.label}</BreadcrumbPage>\n                    )}\n                  </BreadcrumbItem>\n                </React.Fragment>\n              ))}\n            </BreadcrumbList>\n          </Breadcrumb>\n        ) : null}\n      </div>\n\n      {/* Right side content */}\n      {rightContent && (\n        <div className=\"flex items-center space-x-2\">\n          {rightContent}\n        </div>\n      )}\n    </header>\n  );\n}\n"
     },
     {
       "path": "src/app/demo/[name]/blocks/filtered-content-layout-page.tsx",

--- a/public/r/filtered-content-layout.json
+++ b/public/r/filtered-content-layout.json
@@ -10,6 +10,11 @@
     "avatar",
     "input",
     "icons",
+    "breadcrumb",
+    "checkbox",
+    "label",
+    "select",
+    "slider",
     "https://eco-design-system-2.vercel.app/r/styles/sonner.json",
     "https://eco-design-system-2.vercel.app/r/components/panel.json",
     "https://eco-design-system-2.vercel.app/r/components/brand-header.json",
@@ -22,6 +27,12 @@
       "content": "import { Geist_Mono, Inter, Montserrat } from \"next/font/google\";\nimport React, { type ReactNode } from \"react\";\n\nimport { cn } from \"@/lib/utils\";\n\nimport \"@/app/globals.css\";\n\nconst InterSans = Inter({\n  subsets: [\"latin\"],\n  variable: \"--font-sans\",\n});\n\nconst GeistMono = Geist_Mono({\n  subsets: [\"latin\"],\n  variable: \"--font-mono\",\n});\n\nconst MontserratSerif = Montserrat({\n  subsets: [\"latin\"],\n  variable: \"--font-serif\",\n});\n\nexport default function ShellLayout({\n  children,\n}: Readonly<{\n  children: ReactNode;\n}>) {\n  return (\n    <html\n      lang=\"en\"\n      className={cn(\n        InterSans.variable,\n        GeistMono.variable,\n        MontserratSerif.variable,\n        \"bg-background text-foreground\",\n      )}\n    >\n      <body>\n        <main className=\"flex w-full\">\n          <div className=\"w-full\">{children}</div>\n        </main>\n      </body>\n    </html>\n  );\n}\n",
       "type": "registry:file",
       "target": "app/layout.tsx"
+    },
+    {
+      "path": "src/components/ui/header.tsx",
+      "content": "\"use client\";\n\nimport * as React from \"react\";\nimport { cn } from \"@/lib/utils\";\nimport {\n  Breadcrumb,\n  BreadcrumbItem,\n  BreadcrumbLink,\n  BreadcrumbList,\n  BreadcrumbPage,\n  BreadcrumbSeparator,\n} from \"@/components/ui/breadcrumb\";\n\n/**\n * Header component for creating flexible headers that can contain controls for panels.\n *\n * Features:\n * - Flexible layout with left and right content areas\n * - Built-in breadcrumb support\n * - Button and control placement on the right\n * - Consistent styling with design system\n * - Responsive design\n *\n * @example\n * ```tsx\n * <Header\n *   breadcrumbs={[\n *     { label: \"Home\", href: \"/\" },\n *     { label: \"Weather Dashboard\", href: \"/dashboard\" }\n *   ]}\n *   rightContent={<Button>Secondary</Button>}\n * />\n * ```\n */\n\ninterface BreadcrumbItem {\n  label: string;\n  href?: string;\n}\n\ninterface HeaderProps {\n  /** Breadcrumb navigation items */\n  breadcrumbs?: BreadcrumbItem[];\n  /** Content to display on the left side (overrides breadcrumbs) */\n  leftContent?: React.ReactNode;\n  /** Content to display on the right side (buttons, controls, etc.) */\n  rightContent?: React.ReactNode;\n  /** Additional CSS classes */\n  className?: string;\n}\n\n/**\n * Header component for creating flexible headers with breadcrumbs and controls.\n *\n * @param props - Header component props\n * @returns JSX element\n */\nexport function Header({\n  breadcrumbs,\n  leftContent,\n  rightContent,\n  className,\n  ...props\n}: HeaderProps) {\n  return (\n    <header\n      className={cn(\n        \"flex w-full h-12 items-center justify-between border-b border-border bg-background px-3 py-2 shadow-sm\",\n        className\n      )}\n      {...props}\n    >\n      {/* Left side content */}\n      <div className=\"flex items-center\">\n        {leftContent ? (\n          leftContent\n        ) : breadcrumbs ? (\n          <Breadcrumb>\n            <BreadcrumbList>\n              {breadcrumbs.map((item, index) => (\n                <React.Fragment key={index}>\n                  {index > 0 && <BreadcrumbSeparator />}\n                  <BreadcrumbItem>\n                    {item.href ? (\n                      <BreadcrumbLink href={item.href}>\n                        {item.label}\n                      </BreadcrumbLink>\n                    ) : (\n                      <BreadcrumbPage>{item.label}</BreadcrumbPage>\n                    )}\n                  </BreadcrumbItem>\n                </React.Fragment>\n              ))}\n            </BreadcrumbList>\n          </Breadcrumb>\n        ) : null}\n      </div>\n\n      {/* Right side content */}\n      {rightContent && (\n        <div className=\"flex items-center space-x-2\">\n          {rightContent}\n        </div>\n      )}\n    </header>\n  );\n}\n",
+      "type": "registry:component",
+      "target": "components/ui/header.tsx"
     },
     {
       "path": "src/app/demo/[name]/blocks/filtered-content-layout-page.tsx",

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -220,6 +220,11 @@
         "https://eco-design-system-2.vercel.app/r/styles/avatar.json",
         "https://eco-design-system-2.vercel.app/r/styles/input.json",
         "https://eco-design-system-2.vercel.app/r/styles/icons.json",
+        "https://eco-design-system-2.vercel.app/r/styles/breadcrumb.json",
+        "https://eco-design-system-2.vercel.app/r/styles/checkbox.json",
+        "https://eco-design-system-2.vercel.app/r/styles/label.json",
+        "https://eco-design-system-2.vercel.app/r/styles/select.json",
+        "https://eco-design-system-2.vercel.app/r/styles/slider.json",
         "https://eco-design-system-2.vercel.app/r/styles/sonner.json",
         "https://eco-design-system-2.vercel.app/r/components/panel.json",
         "https://eco-design-system-2.vercel.app/r/components/brand-header.json",
@@ -231,6 +236,11 @@
           "path": "src/layouts/shell-layout.tsx",
           "type": "registry:file",
           "target": "app/layout.tsx"
+        },
+        {
+          "path": "src/components/ui/header.tsx",
+          "type": "registry:component",
+          "target": "components/ui/header.tsx"
         },
         {
           "path": "src/app/demo/[name]/blocks/filtered-content-layout-page.tsx",

--- a/registry.json
+++ b/registry.json
@@ -220,6 +220,11 @@
         "avatar",
         "input",
         "icons",
+        "breadcrumb",
+        "checkbox",
+        "label",
+        "select",
+        "slider",
         "https://eco-design-system-2.vercel.app/r/styles/sonner.json",
         "https://eco-design-system-2.vercel.app/r/components/panel.json",
         "https://eco-design-system-2.vercel.app/r/components/brand-header.json",
@@ -231,6 +236,11 @@
           "path": "src/layouts/shell-layout.tsx",
           "type": "registry:file",
           "target": "app/layout.tsx"
+        },
+        {
+          "path": "src/components/ui/header.tsx",
+          "type": "registry:component",
+          "target": "components/ui/header.tsx"
         },
         {
           "path": "src/app/demo/[name]/blocks/filtered-content-layout-page.tsx",
@@ -720,7 +730,7 @@
       "name": "context-menu",
       "type": "registry:ui",
       "title": "Context Menu",
-      "description": "Displays a menu to the user — such as a set of actions or functions — triggered by a right-click",
+      "description": "Displays a menu to the user \u2014 such as a set of actions or functions \u2014 triggered by a right-click",
       "registryDependencies": [
         "https://eco-design-system-2.vercel.app/r/themes/theme.json"
       ],
@@ -837,7 +847,7 @@
       "name": "dropdown-menu",
       "type": "registry:ui",
       "title": "Dropdown Menu",
-      "description": "Displays a menu to the user — such as a set of actions or functions — triggered by a button",
+      "description": "Displays a menu to the user \u2014 such as a set of actions or functions \u2014 triggered by a button",
       "registryDependencies": [
         "https://eco-design-system-2.vercel.app/r/themes/theme.json"
       ],
@@ -1021,7 +1031,7 @@
       "name": "radio-group",
       "type": "registry:ui",
       "title": "Radio Group",
-      "description": "A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time",
+      "description": "A set of checkable buttons\u2014known as radio buttons\u2014where no more than one of the buttons can be checked at a time",
       "registryDependencies": [
         "https://eco-design-system-2.vercel.app/r/themes/theme.json"
       ],
@@ -1066,7 +1076,7 @@
       "name": "select",
       "type": "registry:ui",
       "title": "Select",
-      "description": "Displays a list of options for the user to pick from—triggered by a button",
+      "description": "Displays a list of options for the user to pick from\u2014triggered by a button",
       "registryDependencies": [
         "https://eco-design-system-2.vercel.app/r/themes/theme.json"
       ],
@@ -1202,7 +1212,7 @@
       "name": "tabs",
       "type": "registry:ui",
       "title": "Tabs",
-      "description": "A set of layered sections of content—known as tab panels—that are displayed one at a time",
+      "description": "A set of layered sections of content\u2014known as tab panels\u2014that are displayed one at a time",
       "registryDependencies": [
         "https://eco-design-system-2.vercel.app/r/themes/theme.json"
       ],


### PR DESCRIPTION
- Add header component directly to filtered-content-layout block files array
- Add missing dependencies (breadcrumb, checkbox, label, select, slider)
- Header component now included with target components/ui/header.tsx
- Filtered-content-layout block is now fully standalone matching shadcn pattern
- Fixes: The file '/components/ui/header' cannot be found error in v0